### PR TITLE
Updating cookbook to add more resource wrapping recipes and sysctl

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,13 +18,18 @@ verifier:
 suites:
   - name: default
     run_list:
+      - recipe[iptables]
       - recipe[kernel-modules]
-      - recipe[sysctl::apply]
+      - recipe[owi_docker::sysctl]
       - recipe[owi_docker::docker_service]
       - recipe[owi_docker::docker_compose]
+      - recipe[owi_docker::docker_machine]
       - recipe[owi_docker::users_to_docker_group]
+      - recipe[owi_docker::docker_network]
+      - recipe[owi_docker::docker_volume]
       - recipe[owi_docker::docker_image]
       - recipe[owi_docker::docker_container]
+      - recipe[owi_docker::iptables]
     driver:
       network:
         - ["private_network", {type: "dhcp"}]
@@ -51,10 +56,10 @@ suites:
       "sysctl": {
         "ignore_error": "true",
         "params": {
-          "net.bridge.bridge-nf-call-ip6tables": 1,
-          "net.bridge.bridge-nf-call-iptables": 1,
-          "net.ipv4.conf.all.forwarding": 1,
-          "net.ipv4.ip_forward": 1,
+          "net.bridge.bridge-nf-call-ip6tables": "1",
+          "net.bridge.bridge-nf-call-iptables": "1",
+          "net.ipv4.conf.all.forwarding": "1",
+          "net.ipv4.ip_forward": "1",
           "net.ipv4.ip_local_port_range": "1024 65000",
           "net.ipv4.tcp_tw_reuse": "1",
           "net.ipv4.tcp_fin_timeout": "15",
@@ -76,32 +81,42 @@ suites:
           "net.ipv4.neigh.default.gc_thresh2": "12288",
           "net.ipv4.neigh.default.gc_thresh3": "16384"
         }
-    },
-    "owi_docker" : {
-      "image" : {
-        "nginx" : {
-            "repo" : "nginx",
-            "tag" : "1.13.8"
-        }
       },
-      "container" : {
-        "nginx" : {
-            "repo" : "nginx",
-            "port" : [ "80:80", "443:443" ],
-            "tag" : "1.13.8",
-            "labels" : [
-              "project:default",
-              "software:webserver"
+      "owi_docker" : {
+        "network": {
+          "my_bridge": {
+            "driver": "bridge"
+          }
+        },
+        "volume": {
+          "my_volume": {
+            "action": ["create"]
+          }
+        },
+        "image": {
+          "nginx": {
+              "repo": "nginx",
+              "tag": "1.13.8"
+          }
+        },
+        "container": {
+          "nginx": {
+              "repo": "nginx",
+              "port": [ "80:80", "443:443" ],
+              "tag": "1.13.8",
+              "labels": [
+                "project:default",
+                "software:webserver"
+              ]
+          }
+        },
+        "service": {
+          "default": {
+            "storage_driver": "overlay2",
+            "storage_opts": [
+              "overlay2.override_kernel_check=true"
             ]
-        }
-      },
-      "service" : {
-        "default" : {
-          "storage_driver" : "overlay2",
-          "storage_opts" : [
-            "overlay2.override_kernel_check=true"
-          ]
+          }
         }
       }
     }
-  }

--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,6 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'kernel-modules'
-cookbook 'sysctl', '< 1.0.0'
+cookbook 'sysctl'
 cookbook 'docker'
 cookbook 'iptables'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Updated
+- isuftin@usgs.gov - Cleaned up the logic to define actions going into each resource
+- isuftin@usgs.gov - Added new recipes to the README
+
+### Removed
+- isuftin@usgs.gov - sysctl version constraint
+
+### Added
+- isuftin@usgs.gov - Serverspec testing for docker_network recipe
+- isuftin@usgs.gov - Serverspec testing for docker_volume recipe
+- isuftin@usgs.gov - wrapper recipe for Docker cookbook docker_network resource
+- isuftin@usgs.gov - wrapper recipe for Docker cookbook docker_volume resource
+- isuftin@usgs.gov - sysctl serverspec testing
+- isuftin@usgs.gov - sysctl cookbook dependency to metadata and Berksfile
+- isuftin@usgs.gov - sysctl recipe to work against sysctl cookbook's sysctl_param
+resource
+
 ## [0.0.12] - 2017-05-04
 ### Updated
 - isuftin@usgs.gov - Fix an issue with the upstream iptables cookbook not adding

--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ Typically, Docker requires sudo access to perform commands. In order to have use
 array and run the `users_to_docker_group` recipe. This recipe obviously needs to be
 run after the Docker service is installed via the `docker_service` recipe.
 
+### Sysctl
+---
+
+The `owi_docker::sysctl` allows you to pass in updates to the OS sysctl values if needed.
+This uses the upstream sysctl cookbook. Look at .kitchen.yml for an idea of how to
+pass in requirements.
+
+An attributes example would look like:
+
+```
+"sysctl": {
+  "ignore_error": "true",
+  "params": {
+    "net.bridge.bridge-nf-call-ip6tables": "1",
+    "net.bridge.bridge-nf-call-iptables": "1"
+  }
+}
+```
+
 ### Docker Image
 ---
 
@@ -49,12 +68,33 @@ The `owi_docker::docker_image` recipe is a wrapper around the upstream Docker co
 library. Use the same properties in this recipe as you would passing to the Docker
 cookbook docker_image library.
 
+### Docker Service
+---
+
+The `owi_docker::docker_service` recipe is a wrapper around the upstream Docker cookbook
+docker_service library. Use the same properties in this recipe as you would passing to the Docker
+cookbook docker_service library.
+
+### Docker Volume
+---
+
+The `owi_docker::docker_volime` recipe is a wrapper around the upstream Docker cookbook
+docker_volume library. Use the same properties in this recipe as you would passing to the Docker
+cookbook docker_volume library.
+
+### Docker Network
+---
+
+The `owi_docker::docker_network` recipe is a wrapper around the upstream Docker cookbook
+docker_network library. Use the same properties in this recipe as you would passing to the Docker
+cookbook docker_network library.
+
 ### Docker Container
 ---
 
 The `owi_docker::docker_container` recipe is a wrapper around the upstream Docker cookbook
 library. Use the same properties in this recipe as you would passing to the Docker
-cookbook docker_container library. 
+cookbook docker_container library.
 
 ### Docker Machine
 ---
@@ -71,3 +111,11 @@ Docker Compose is also available to be installed. Simply specify which version y
 want using the `default['owi_docker']['compose']['version']` attribute. You can also
 add `default['owi_docker']['compose']['binary_location']` if you wish to install from
 a binary that you host. To install, run the `owi_docker::docker_compose recipe`
+
+### IPTables
+---
+
+This recipe preserves the iptables rules as they are set when the recipe is run.
+The rules are then restored via a delay (end of the Chef run). This ensures that
+the iptables rules for Docker are not wiped by a secondary process. This can happen
+if another cookbook uses the community iptables cookbook to lay down some rules.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ default['owi_docker']['machine']['version'] = '0.14.0'
 # Specify the version of Docker Compose required. Otherwise, use the
 # `default['owi_docker']['compose'][binary_location]` to specify your own binary
 # location
-default['owi_docker']['compose']['version'] = '1.21.0'
+default['owi_docker']['compose']['version'] = '1.21.1'
 
 default['owi_docker']['service'] = {}
 default['owi_docker']['container'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,3 +21,4 @@ supports 'centos', '>= 7.0'
 
 depends 'docker'
 depends 'iptables'
+depends 'sysctl'

--- a/recipes/docker_container.rb
+++ b/recipes/docker_container.rb
@@ -5,12 +5,6 @@
 return unless node['owi_docker'].attribute?('container')
 
 node['owi_docker']['container'].each do |container_name, container_properties|
-  actions = %i[run]
-
-  if container_properties.key?('actions')
-    actions = [container_properties['actions'].map(&:to_sym)]
-  end
-
   docker_container container_name do
     attach_stderr container_properties['attach_stderr'] unless container_properties['attach_stderr'].nil?
     attach_stdin container_properties['attach_stdin'] unless container_properties['attach_stdin'].nil?
@@ -85,7 +79,7 @@ node['owi_docker']['container'].each do |container_name, container_properties|
     volumes_from container_properties['volumes_from'] unless container_properties['volumes_from'].nil?
     working_dir container_properties['working_dir'] unless container_properties['working_dir'].nil?
 
-    action actions
+    action container_properties.key?('action') ? container_properties['action'].map(&:to_sym) : %i[run]
 
     subscribes :redeploy, "docker_image[#{container_name}]", :immediately
   end

--- a/recipes/docker_image.rb
+++ b/recipes/docker_image.rb
@@ -5,12 +5,6 @@
 return unless node['owi_docker'].attribute?('image')
 
 node['owi_docker']['image'].each do |image_name, image_properties|
-  actions = %i[pull]
-
-  if image_properties.key?('actions')
-    actions = [image_properties['actions'].map(&:to_sym)]
-  end
-
   docker_image image_name do
     destination image_properties['destination'] unless image_properties['destination'].nil?
     force image_properties['force'] unless image_properties['force'].nil?
@@ -24,6 +18,6 @@ node['owi_docker']['image'].each do |image_name, image_properties|
     source image_properties['source'] unless image_properties['source'].nil?
     tag image_properties['tag'] unless image_properties['tag'].nil?
 
-    action actions
+    action image_properties.key?('action') ? image_properties['action'].map(&:to_sym) : %i[pull]
   end
 end

--- a/recipes/docker_network.rb
+++ b/recipes/docker_network.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: owi_docker
+# Recipe:: docker_network
+# Description:: Wraps the Docker cookbook's docker_network resource
+
+return unless node['owi_docker'].attribute?('network')
+
+node['owi_docker']['network'].each do |network_name, network_properties|
+  docker_network network_name do
+    aux_address network_properties['aux_address'] unless network_properties['aux_address'].nil?
+    container network_properties['container'] unless network_properties['container'].nil?
+    driver network_properties['driver'] unless network_properties['driver'].nil?
+    driver_opts network_properties['driver_opts'] unless network_properties['driver_opts'].nil?
+    enable_ipv6 network_properties['enable_ipv6'] unless network_properties['enable_ipv6'].nil?
+    gateway network_properties['gateway'] unless network_properties['gateway'].nil?
+    host network_properties['host'] unless network_properties['host'].nil?
+    id network_properties['id'] unless network_properties['id'].nil?
+    internal network_properties['internal'] unless network_properties['internal'].nil?
+    ip_range network_properties['ip_range'] unless network_properties['ip_range'].nil?
+    ipam_driver network_properties['ipam_driver'] unless network_properties['ipam_driver'].nil?
+    network network_properties['network'] unless network_properties['network'].nil?
+    subnet network_properties['subnet'] unless network_properties['subnet'].nil?
+
+    action network_properties.key?('action') ? network_properties['action'].map(&:to_sym) : %i[create]
+  end
+end

--- a/recipes/docker_service.rb
+++ b/recipes/docker_service.rb
@@ -3,11 +3,6 @@
 # Recipe:: docker_service
 
 node['owi_docker']['service'].each do |service_name, service_properties|
-  actions = %i[create start]
-
-  if service_properties.key?('actions')
-    actions = [service_properties['actions'].map(&:to_sym)]
-  end
 
   docker_service service_name do
     api_cors_header service_properties['api_cors_header'] unless service_properties['api_cors_header'].nil?
@@ -80,7 +75,6 @@ node['owi_docker']['service'].each do |service_name, service_properties|
     userland_proxy service_properties['userland_proxy'] unless service_properties['userland_proxy'].nil?
     userns_remap service_properties['userns_remap'] unless service_properties['userns_remap'].nil?
     version service_properties['version'] unless service_properties['version'].nil?
-
-    action actions
+    action service_properties.key?('action') ? service_properties['action'].map(&:to_sym) : %i[create start]
   end
 end

--- a/recipes/docker_volume.rb
+++ b/recipes/docker_volume.rb
@@ -1,0 +1,16 @@
+#
+# Cookbook Name:: owi_docker
+# Recipe:: docker_volume
+# Description:: Wraps the Docker cookbook's docker_volume resource
+
+return unless node['owi_docker'].attribute?('volume')
+
+node['owi_docker']['volume'].each do |volume_name, volume_properties|
+  docker_volume volume_name do
+    driver volume_properties['driver'] unless volume_properties['driver'].nil?
+    host volume_properties['host'] unless volume_properties['host'].nil?
+    opts volume_properties['opts'] unless volume_properties['opts'].nil?
+    volume volume_properties['volume'] unless volume_properties['volume'].nil?
+    action volume_properties.key?('action') ? volume_properties['action'].map(&:to_sym) : %i[create]
+  end
+end

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: owi_docker
+# Recipe:: sysctl
+# Description: Updates sysctl policies using the third-party sysctl cookbook
+# and parameters specific to that cookbook coming from the default attributes.
+
+node['sysctl']['params'].each do |param, value|
+  sysctl_param param do
+    key param
+    value value
+    only_if "sysctl -n #{param}"
+  end
+end

--- a/test/integration/centos7/inspec/controls/docker_network_spec.rb
+++ b/test/integration/centos7/inspec/controls/docker_network_spec.rb
@@ -1,0 +1,3 @@
+describe command('docker network ls -f driver=bridge | grep my_bridge') do
+  its('exit_status') { should eq 0 }
+end

--- a/test/integration/centos7/inspec/controls/docker_volume_spec.rb
+++ b/test/integration/centos7/inspec/controls/docker_volume_spec.rb
@@ -1,0 +1,3 @@
+describe command('docker volume ls | grep my_volume') do
+  its('exit_status') { should eq 0 }
+end

--- a/test/integration/centos7/inspec/controls/sysctl_spec.rb
+++ b/test/integration/centos7/inspec/controls/sysctl_spec.rb
@@ -1,0 +1,29 @@
+sysctl_params = {
+  "net.bridge.bridge-nf-call-ip6tables"=> "1",
+  "net.bridge.bridge-nf-call-iptables"=> "1",
+  "net.ipv4.conf.all.forwarding"=> "1",
+  "net.ipv4.ip_forward"=> "1",
+  "net.ipv4.tcp_tw_reuse"=> "1",
+  "net.ipv4.tcp_fin_timeout"=> "15",
+  "net.core.somaxconn"=> "4096",
+  "net.core.netdev_max_backlog"=> "4096",
+  "net.core.rmem_max"=> "16777216",
+  "net.core.wmem_max"=> "16777216",
+  "net.ipv4.tcp_max_syn_backlog"=> "20480",
+  "net.ipv4.tcp_max_tw_buckets"=> "400000",
+  "net.ipv4.tcp_no_metrics_save"=> "1",
+  "net.ipv4.tcp_syn_retries"=> "2",
+  "net.ipv4.tcp_synack_retries"=> "2",
+  "vm.min_free_kbytes"=> "65536",
+  "net.netfilter.nf_conntrack_max"=> "262144",
+  "net.netfilter.nf_conntrack_tcp_timeout_established"=> "86400",
+  "net.ipv4.neigh.default.gc_thresh1"=> "8096",
+  "net.ipv4.neigh.default.gc_thresh2"=> "12288",
+  "net.ipv4.neigh.default.gc_thresh3"=> "16384"
+}
+
+sysctl_params.each do |param, value|
+  describe command("sysctl -n #{param}") do
+    its(:stdout) { should match value }
+  end
+end


### PR DESCRIPTION
### Updated
- isuftin@usgs.gov - Cleaned up the logic to define actions going into each resource
- isuftin@usgs.gov - Added new recipes to the README

### Removed
- isuftin@usgs.gov - sysctl version constraint

### Added
- isuftin@usgs.gov - Serverspec testing for docker_network recipe
- isuftin@usgs.gov - Serverspec testing for docker_volume recipe
- isuftin@usgs.gov - wrapper recipe for Docker cookbook docker_network resource
- isuftin@usgs.gov - wrapper recipe for Docker cookbook docker_volume resource
- isuftin@usgs.gov - sysctl serverspec testing
- isuftin@usgs.gov - sysctl cookbook dependency to metadata and Berksfile
- isuftin@usgs.gov - sysctl recipe to work against sysctl cookbook's sysctl_param
resource